### PR TITLE
improve from handling in actionmailer delivery method

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ You can use TMS from the mail gem or ActionMailer as a delivery method.
 
 Gemfile
 ```ruby
-gem 'govdelivery-tms', :require=>'govdelivery-tms/mail/delivery_method'
+gem 'govdelivery-tms', :require=>'govdelivery/tms/mail/delivery_method'
 ```
 
 config/environment.rb
@@ -246,7 +246,7 @@ config/environment.rb
 config.action_mailer.delivery_method = :govdelivery_tms
 config.action_mailer.govdelivery_tms_settings = {
     :auth_token=>'auth_token',
-    :api_root=>'https://stage-tms.govdelivery.com'
+    :api_root=>'https://tms.govdelivery.com'
     }
 ```
 

--- a/lib/govdelivery/tms/mail/delivery_method.rb
+++ b/lib/govdelivery/tms/mail/delivery_method.rb
@@ -36,12 +36,12 @@ module GovDelivery::TMS
                    mail.body
                end.decoded
 
-        message_params = {
-          from_name:  mail[:from] ? mail[:from].display_names.first : nil,
-          from_email: mail.from.try(:first),
-          subject:    mail.subject,
-          body:       body
-        }.delete_if { |k, v| v.nil? }
+        message_params              = {
+          subject: mail.subject,
+          body:    body
+        }
+        message_params[:from_email] = mail.from.first unless mail.from.blank?
+        message_params[:from_name]  = mail[:from].display_names.first unless mail[:from].blank?
 
         tms_message = client.email_messages.build(message_params)
 

--- a/spec/mail/delivery_method_spec.rb
+++ b/spec/mail/delivery_method_spec.rb
@@ -7,45 +7,78 @@ describe GovDelivery::TMS::Mail::DeliveryMethod do
   let(:email_messages) { double('email_messages') }
   let(:tms_message) { double('tms_message', recipients: double(build: GovDelivery::TMS::Recipient.new('href'))) }
 
-  it 'should work with a basic Mail::Message' do
-    mail = Mail.new do
-      subject 'hi'
-      from '"My mom" <my@mom.com>'
-      to '"A Nice Fellow" <tyler@sink.govdelivery.com>'
-      body '<blink>HI</blink>'
-    end
+  before do
     allow(client).to receive(:email_messages).and_return(email_messages)
     allow(subject).to receive(:client).and_return(client)
-    expect(email_messages).to receive(:build).with(
-      from_name: mail[:from].display_names.first,
-      subject:   mail.subject,
-      body:      '<blink>HI</blink>'
-    ).and_return(tms_message)
-    expect(tms_message).to receive(:post!).and_return(true)
-
-    subject.deliver!(mail)
   end
 
-  it 'should work with a multipart Mail::Message' do
-    mail = Mail.new do
-      subject 'hi'
-      from '"My mom" <my@mom.com>'
-      to '"A Nice Fellow" <tyler@sink.govdelivery.com>'
-
-      html_part do
-        content_type 'text/html; charset=UTF-8'
-        body '<blink>HTML</blink>'
+  context 'a basic Mail::Message with all options' do
+    let(:mail) {
+      Mail.new do
+        subject 'hi'
+        from '"My mom" <my@mom.com>'
+        to '"A Nice Fellow" <tyler@sink.govdelivery.com>'
+        body '<blink>HI</blink>'
       end
-    end
-    allow(client).to receive(:email_messages).and_return(email_messages)
-    allow(subject).to receive(:client).and_return(client)
-    expect(email_messages).to receive(:build).with(
-      from_name: mail[:from].display_names.first,
-      subject:   mail.subject,
-      body:      '<blink>HTML</blink>'
-    ).and_return(tms_message)
-    expect(tms_message).to receive(:post!).and_return(true)
+    }
 
-    subject.deliver!(mail)
+    it 'should get sent' do
+      expect(email_messages).to receive(:build).with(
+                                  from_name:  mail[:from].display_names.first,
+                                  from_email: mail.from.first,
+                                  subject:    mail.subject,
+                                  body:       '<blink>HI</blink>'
+                                ).and_return(tms_message)
+      expect(tms_message).to receive(:post!).and_return(true)
+
+      subject.deliver!(mail)
+    end
+  end
+
+  context 'a basic Mail::Message with minimal options' do
+    let(:mail) {
+      Mail.new do
+        subject 'hi'
+        to '"A Nice Fellow" <tyler@sink.govdelivery.com>'
+        body '<blink>HI</blink>'
+      end
+    }
+
+    it 'should get sent' do
+      expect(email_messages).to receive(:build).with(
+                                  subject: mail.subject,
+                                  body:    '<blink>HI</blink>'
+                                ).and_return(tms_message)
+      expect(tms_message).to receive(:post!).and_return(true)
+
+      subject.deliver!(mail)
+    end
+  end
+
+  context "a multipart Mail::Message" do
+    let(:mail) {
+      Mail.new do
+        subject 'hi'
+        from '"My mom" <my@mom.com>'
+        to '"A Nice Fellow" <tyler@sink.govdelivery.com>'
+
+        html_part do
+          content_type 'text/html; charset=UTF-8'
+          body '<blink>HTML</blink>'
+        end
+      end
+    }
+
+    it 'should send' do
+      expect(email_messages).to receive(:build).with(
+                                  from_name:  mail[:from].display_names.first,
+                                  from_email: mail.from.first,
+                                  subject:    mail.subject,
+                                  body:       '<blink>HTML</blink>'
+                                ).and_return(tms_message)
+      expect(tms_message).to receive(:post!).and_return(true)
+
+      subject.deliver!(mail)
+    end
   end
 end


### PR DESCRIPTION
* Update the instructions for requiring (maybe we should make this a railtie someday?)
* Don't blow up if from_email isn't specified since there is an account default.
* add spec for minimal set of args
