### PR TITLE
Updated sms and email templates to have writable uuid.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,22 @@ message.post
 ### Creating an Email Template
 
 ```ruby
-template = client.email_templates.build(subject: 'A templated subject',
+template = client.email_templates.build(uuid: 'a-new-template',
+                                        subject: 'A templated subject',
                                         body: 'Hi [[name]], this body is from a template.',
                                         macros: {"name"=>"person"})
 template.post
+```
+
+### Updating an Email Template
+
+*Note: `uuid` cannot be updated.*
+
+```ruby
+template = client.email_templates.build(:href => 'template/email/a-new-template')
+template.get
+template.body = 'Hi [[name]], this body is from a new template.'
+template.put
 ```
 
 ### Sending an Email using a Template
@@ -106,12 +118,44 @@ Assuming you created `template` above:
 
 ```ruby
 message = client.email_messages.build
-message.links[:email_template] = template.id
+message.links[:email_template] = template.uuid
 message.recipients.build(:email=>'jim@example.com', :macros=>{"name"=>"Jim"})
 message.recipients.build(:email=>'amy@example.com', :macros=>{"name"=>"Amy"})
 message.recipients.build(:email=>'bill@example.com')
 message.post
 ```
+
+### Creating an SMS Template
+
+```ruby
+template = client.sms_templates.build(uuid: 'a_new-template',
+                                      body: 'Hi, [[name]] this is a tempalte.')
+template.post
+```
+
+### Updating an SMS Template
+
+*Note: `uuid` cannot be updated.*
+
+```ruby
+template = client.sms_templates.build(href: 'template/sms/a_new-template')
+template.get
+template.body = 'Hi, [[name]] this is a new tempalte.'
+template.put
+```
+
+### Sending an SMS Message using a Template
+
+Assuming you've created `template` above:
+
+```ruby
+message = client.email_messages.build
+message.links[:sms_template] = template.uuid
+message.recipients.build(:phone=>'5551112222')
+message.recipients.build(:phone=>'5551112223')
+message.post
+```
+
 
 Webhooks
 -------

--- a/lib/govdelivery/tms/resource/email_template.rb
+++ b/lib/govdelivery/tms/resource/email_template.rb
@@ -3,7 +3,7 @@ module GovDelivery::TMS #:nodoc:
     include InstanceResource
 
     # @!parse attr_accessor :body, :subject, :link_tracking_parameters, :macros, :open_tracking_enabled, :click_tracking_enabled
-    writeable_attributes :body, :subject, :link_tracking_parameters, :macros, :open_tracking_enabled, :click_tracking_enabled
+    writeable_attributes :body, :subject, :link_tracking_parameters, :macros, :open_tracking_enabled, :click_tracking_enabled, :uuid
 
     linkable_attributes :from_address
 

--- a/lib/govdelivery/tms/resource/sms_template.rb
+++ b/lib/govdelivery/tms/resource/sms_template.rb
@@ -3,7 +3,7 @@ module GovDelivery::TMS #:nodoc:
     include InstanceResource
 
     # @!parse attr_accessor :body
-    writeable_attributes :body
+    writeable_attributes :body, :uuid
 
     # @!parse attr_reader :id, :created_at
     readonly_attributes :id, :created_at

--- a/lib/govdelivery/tms/version.rb
+++ b/lib/govdelivery/tms/version.rb
@@ -1,5 +1,5 @@
 module GovDelivery
   module TMS #:nodoc:
-    VERSION = '0.8.13'
+    VERSION = '0.8.14'
   end
 end

--- a/spec/email_message_spec.rb
+++ b/spec/email_message_spec.rb
@@ -86,7 +86,7 @@ describe GovDelivery::TMS::EmailMessage do
                    'reply_to'   => 'replyto@evotest.govdelivery.com',
                    'recipients' => [{ email: 'billy@evotest.govdelivery.com' }],
                    'created_at' => 'time',
-                   '_links'     => { 'self' => '/messages/email/1', 'email_template' => '/templates/email/1' }
+                   '_links'     => { 'self' => '/messages/email/new-template', 'email_template' => '/templates/email/new-template' }
                   }
       expect(@message.client).to receive('get').with(@message.href).and_return(double('response', status: 200, body: response))
       @message.get

--- a/spec/email_template_spec.rb
+++ b/spec/email_template_spec.rb
@@ -13,6 +13,7 @@ describe GovDelivery::TMS::EmailTemplate do
       response = [
         {
           'id'                         => '1',
+          'uuid'                       => 'new-template',
           'body'                       => 'Template 1',
           'subject'                    => 'This is the template 1 subject',
           'link_tracking_parameters'   => 'test=ok&hello=world',
@@ -20,7 +21,7 @@ describe GovDelivery::TMS::EmailTemplate do
           'open_tracking_enabled'      => true,
           'click_tracking_enabled'     => true,
           'created_at'                 => 'sometime',
-          '_links'                     => { 'self' => '/templates/email/1', 'account' => '/accounts/1', 'from_address' => '/from_addresses/1' }
+          '_links'                     => { 'self' => '/templates/email/new-template', 'account' => '/accounts/1', 'from_address' => '/from_addresses/1' }
         }
       ]
 
@@ -35,7 +36,8 @@ describe GovDelivery::TMS::EmailTemplate do
       double('client')
     end
     before do
-      @template = GovDelivery::TMS::EmailTemplate.new(client, '/templates/email',         body:                       'Template 1',
+      @template = GovDelivery::TMS::EmailTemplate.new(client, '/templates/email',         uuid:                       'new-template',
+                                                                                          body:                       'Template 1',
                                                                                           subject:                    'This is the template 1 subject',
                                                                                           link_tracking_parameters:   'test=ok&hello=world',
                                                                                           macros:                     { 'MACRO1' => '1' },
@@ -70,6 +72,7 @@ describe GovDelivery::TMS::EmailTemplate do
     it 'should post successfully' do
       response = {
         'id'                         => '1',
+        'uuid'                       => 'new-template',
         'body'                       => 'Template 1',
         'subject'                    => 'This is the template 1 subject',
         'link_tracking_parameters'   => 'test=ok&hello=world',
@@ -77,7 +80,7 @@ describe GovDelivery::TMS::EmailTemplate do
         'open_tracking_enabled'      => true,
         'click_tracking_enabled'     => true,
         'created_at'                 => 'sometime',
-        '_links'                     => { 'self' => '/templates/email/1', 'account' => '/accounts/1', 'from_address' => '/from_addresses/1' }
+        '_links'                     => { 'self' => '/templates/email/new-template', 'account' => '/accounts/1', 'from_address' => '/from_addresses/1' }
       }
       expect(@template.client).to receive('post').with(@template).and_return(double('response', status: 201, body: response))
       @template.post

--- a/spec/email_template_spec.rb
+++ b/spec/email_template_spec.rb
@@ -85,6 +85,7 @@ describe GovDelivery::TMS::EmailTemplate do
       expect(@template.client).to receive('post').with(@template).and_return(double('response', status: 201, body: response))
       @template.post
       expect(@template.id).to eq('1')
+      expect(@template.uuid).to eq('new-template')
       expect(@template.body).to eq('Template 1')
       expect(@template.subject).to eq('This is the template 1 subject')
       expect(@template.link_tracking_parameters).to eq('test=ok&hello=world')


### PR DESCRIPTION
SMS and Email templates now support a uuid attribute that can be set on creation and used as a reference. Updated the templates to support those attributes and added additional documentation around using templates.