### PR TITLE
remove mime-types version restriction

### DIFF
--- a/govdelivery-tms.gemspec
+++ b/govdelivery-tms.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'faraday'
   s.add_runtime_dependency 'faraday_middleware'
-  s.add_runtime_dependency 'mime-types', ['< 3.0']
+  s.add_runtime_dependency 'mime-types'
 
   s.files       = %w(
     Gemfile

--- a/lib/govdelivery/tms/version.rb
+++ b/lib/govdelivery/tms/version.rb
@@ -1,5 +1,5 @@
 module GovDelivery
   module TMS #:nodoc:
-    VERSION = '0.10.1'.freeze
+    VERSION = '0.10.2'.freeze
   end
 end


### PR DESCRIPTION
Locking 'mime-types' down to < 3.0 is causing dependency conflicts for me with other gems.

This was originally done to ["Pin mime-types to a version that supports jRuby"](https://github.com/govdelivery/govdelivery-tms-ruby/commit/15cdf4583368c446fe269925b3ba0bfd7e29e30f).

Is this still a concern?  It appears that 'mime-types' is compatible now with jruby 9.2.0.0:  [source](https://travis-ci.org/mime-types/ruby-mime-types).